### PR TITLE
Remove plan names from the component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 .project
+node_modules/

--- a/lib/pricing-grid-component.js
+++ b/lib/pricing-grid-component.js
@@ -128,28 +128,21 @@ class PricingGridComponent extends PolymerElement {
           background-color: #e8e8e8;
           box-shadow:inset 0px 0px 0px 2px #000000;
         }
-        .gridRow[selected] .tierName,.gridRow[selected] .tierPrice {
+        .gridRow[selected] .tierDisplays,.gridRow[selected] .tierPrice {
           color: black;
         }
 
         .tierDescription {
           align-items: center;
         }
-        .tierName {
-          font-size: 18px;;
-          font-weight: bold;
-          font-style: normal;
-          font-stretch: normal;
-          letter-spacing: normal;
-          color: #999999;
-          margin-right: 1em;
-        }
         .tierDisplays {
+          font-size: 18px;
           font-weight: 500;
           font-style: normal;
           font-stretch: normal;
           letter-spacing: normal;
           color: #999999;
+          margin-right: 1em;
         }
         .tierPrice {
           font-size: 18px;
@@ -169,16 +162,13 @@ class PricingGridComponent extends PolymerElement {
           .gridRow {
             text-align: left;
           }
-          .tierName {
-            margin: 0;
-            font-size: 1em;
-          }
           .tierPrice {
             font-size: 1em;
           }
           .tierDisplays {
             margin: 0;
             display: block;
+            font-size: 1em;
           }
           .tierDescription {
             flex-direction: column;
@@ -190,7 +180,6 @@ class PricingGridComponent extends PolymerElement {
         <div id="gridContainer" class="gridRectangle">
           <div id="tierStarter" class="gridRow" selected$=[[isStarter]]>
             <div class="tierDescription">
-              <span class="tierName">Starter</span>
               <span class="tierDisplays">
                 [[getLowerLimit(pricingData, period, 0)]]-[[getUpperLimit(pricingData, period, 0)]] Displays
               </span>
@@ -199,7 +188,6 @@ class PricingGridComponent extends PolymerElement {
           </div>
           <div id="tierBasic" class="gridRow" selected$=[[isBasic]]>
             <div class="tierDescription">
-              <span class="tierName">Basic</span>
               <span class="tierDisplays">
                 [[getLowerLimit(pricingData, period, 1)]]-[[getUpperLimit(pricingData, period, 1)]] Displays
               </span>
@@ -208,7 +196,6 @@ class PricingGridComponent extends PolymerElement {
           </div>
           <div id="tierAdvanced" class="gridRow" selected$=[[isAdvanced]]>
             <div class="tierDescription">
-              <span class="tierName">Advanced</span>
               <span class="tierDisplays">
                 [[getLowerLimit(pricingData, period, 2)]]-[[getUpperLimit(pricingData, period, 2)]] Displays
               </span>
@@ -217,7 +204,6 @@ class PricingGridComponent extends PolymerElement {
           </div>
           <div id="tierEnterprise" class="gridRow" selected$=[[isEnterprise]]>
             <div class="tierDescription">
-              <span class="tierName">Enterprise</span>
               <span class="tierDisplays">
                 [[getLowerLimit(pricingData, period, 3)]] or more Displays
               </span>

--- a/pricing-grid-component-test.html
+++ b/pricing-grid-component-test.html
@@ -138,7 +138,7 @@
           component.pricingData = pricingData;
           component.period = "yearly"
 
-          chai.assert.equal(advancedTier.querySelectorAll("span")[2].innerText, "$7.33");
+          chai.assert.equal(advancedTier.querySelectorAll("span")[1].innerText, "$7.33");
         });
 
         it("shows monthly pricing when monthly period is selected", ()=>{
@@ -151,7 +151,7 @@
           component.pricingData = pricingData;
           component.period = "monthly"
 
-          chai.assert.equal(advancedTier.querySelectorAll("span")[2].innerText, expectedPrice);
+          chai.assert.equal(advancedTier.querySelectorAll("span")[1].innerText, expectedPrice);
         });
       });
     </script>

--- a/pricing-grid-component.mjs
+++ b/pricing-grid-component.mjs
@@ -128,28 +128,21 @@ class PricingGridComponent extends PolymerElement {
           background-color: #e8e8e8;
           box-shadow:inset 0px 0px 0px 2px #000000;
         }
-        .gridRow[selected] .tierName,.gridRow[selected] .tierPrice {
+        .gridRow[selected] .tierDisplays,.gridRow[selected] .tierPrice {
           color: black;
         }
 
         .tierDescription {
           align-items: center;
         }
-        .tierName {
-          font-size: 18px;;
-          font-weight: bold;
-          font-style: normal;
-          font-stretch: normal;
-          letter-spacing: normal;
-          color: #999999;
-          margin-right: 1em;
-        }
         .tierDisplays {
+          font-size: 18px;
           font-weight: 500;
           font-style: normal;
           font-stretch: normal;
           letter-spacing: normal;
           color: #999999;
+          margin-right: 1em;
         }
         .tierPrice {
           font-size: 18px;
@@ -169,16 +162,13 @@ class PricingGridComponent extends PolymerElement {
           .gridRow {
             text-align: left;
           }
-          .tierName {
-            margin: 0;
-            font-size: 1em;
-          }
           .tierPrice {
             font-size: 1em;
           }
           .tierDisplays {
             margin: 0;
             display: block;
+            font-size: 1em;
           }
           .tierDescription {
             flex-direction: column;
@@ -190,7 +180,6 @@ class PricingGridComponent extends PolymerElement {
         <div id="gridContainer" class="gridRectangle">
           <div id="tierStarter" class="gridRow" selected$=[[isStarter]]>
             <div class="tierDescription">
-              <span class="tierName">Starter</span>
               <span class="tierDisplays">
                 [[getLowerLimit(pricingData, period, 0)]]-[[getUpperLimit(pricingData, period, 0)]] Displays
               </span>
@@ -199,7 +188,6 @@ class PricingGridComponent extends PolymerElement {
           </div>
           <div id="tierBasic" class="gridRow" selected$=[[isBasic]]>
             <div class="tierDescription">
-              <span class="tierName">Basic</span>
               <span class="tierDisplays">
                 [[getLowerLimit(pricingData, period, 1)]]-[[getUpperLimit(pricingData, period, 1)]] Displays
               </span>
@@ -208,7 +196,6 @@ class PricingGridComponent extends PolymerElement {
           </div>
           <div id="tierAdvanced" class="gridRow" selected$=[[isAdvanced]]>
             <div class="tierDescription">
-              <span class="tierName">Advanced</span>
               <span class="tierDisplays">
                 [[getLowerLimit(pricingData, period, 2)]]-[[getUpperLimit(pricingData, period, 2)]] Displays
               </span>
@@ -217,7 +204,6 @@ class PricingGridComponent extends PolymerElement {
           </div>
           <div id="tierEnterprise" class="gridRow" selected$=[[isEnterprise]]>
             <div class="tierDescription">
-              <span class="tierName">Enterprise</span>
               <span class="tierDisplays">
                 [[getLowerLimit(pricingData, period, 3)]] or more Displays
               </span>


### PR DESCRIPTION
## Description
Remove plan names from the component

Update styling

Add node_modules to gitignore

## Motivation and Context
We no longer use plans but tiers instead. Removing names as they are confusing.

## How Has This Been Tested?
Staged in Apps at https://apps-stage-18.risevision.com/

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
